### PR TITLE
Changes from background agent bc-69a9be9a-2233-40d6-845c-4d4385a8db83

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -11,12 +11,8 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-def get_db():
-    return auth_service.get_db()
-
-
 @router.post("/login", response_model=schemas.Token)
-async def login(credentials: schemas.LoginRequest, db: Session = Depends(get_db)):
+async def login(credentials: schemas.LoginRequest, db: Session = Depends(auth_service.get_db)):
     """
     Login endpoint that accepts JSON credentials
     """
@@ -44,7 +40,7 @@ async def login(credentials: schemas.LoginRequest, db: Session = Depends(get_db)
 
 
 @router.post("/login-form", response_model=schemas.Token)
-async def login_form(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
+async def login_form(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(auth_service.get_db)):
     """
     Login endpoint for form data (OAuth2 compatible)
     """
@@ -68,7 +64,7 @@ async def login_form(form_data: OAuth2PasswordRequestForm = Depends(), db: Sessi
 
 
 @router.post("/register", response_model=schemas.User)
-def register(user: schemas.UserCreate, db: Session = Depends(get_db)):
+def register(user: schemas.UserCreate, db: Session = Depends(auth_service.get_db)):
     """
     Register a new user
     """

--- a/app/routes/vulnerability.py
+++ b/app/routes/vulnerability.py
@@ -7,33 +7,32 @@ from app.services import vulnerability as vuln_service, auth as auth_service
 router = APIRouter(dependencies=[Depends(auth_service.get_current_user)])
 
 
-def get_db():
-    return auth_service.get_db()
+
 
 
 @router.get("/months", response_model=list[str])
-def list_months(db: Session = Depends(get_db)):
+def list_months(db: Session = Depends(auth_service.get_db)):
     return vuln_service.get_months(db)
 
 
 @router.post("/upload")
-def upload_csv(month: str, file: UploadFile = File(...), db: Session = Depends(get_db)):
+def upload_csv(month: str, file: UploadFile = File(...), db: Session = Depends(auth_service.get_db)):
     vuln_service.save_csv(db, file, month)
     return {"message": "Upload successful"}
 
 
 @router.get("/list", response_model=list[schemas.Vulnerability])
-def list_vulns(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+def list_vulns(skip: int = 0, limit: int = 100, db: Session = Depends(auth_service.get_db)):
     return vuln_service.list_vulnerabilities(db, skip=skip, limit=limit)
 
 
 @router.delete("/uploads/{month}")
-def delete_month(month: str, db: Session = Depends(get_db)):
+def delete_month(month: str, db: Session = Depends(auth_service.get_db)):
     vuln_service.delete_by_month(db, month)
     return {"message": "Deleted"}
 
 
 @router.delete("/uploads/all")
-def delete_all(db: Session = Depends(get_db)):
+def delete_all(db: Session = Depends(auth_service.get_db)):
     vuln_service.delete_all(db)
     return {"message": "All deleted"}


### PR DESCRIPTION
Correct database dependency injection to resolve `AttributeError: 'generator' object has no attribute 'query'`.

The `get_db` helper functions in the route files were incorrectly returning the generator object from `auth_service.get_db()` instead of yielding the database session. This caused FastAPI's dependency injection to receive a generator instead of a session object, leading to the `AttributeError`. The fix directly uses `auth_service.get_db` as the dependency, ensuring the correct session object is provided.

---

[Open in Web](https://cursor.com/agents?id=bc-69a9be9a-2233-40d6-845c-4d4385a8db83) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-69a9be9a-2233-40d6-845c-4d4385a8db83) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)